### PR TITLE
fix: add slash to RENKU_BASE_URL_PATH

### DIFF
--- a/build.go
+++ b/build.go
@@ -77,7 +77,7 @@ func Build(
 		if launch {
 			command := "codium-server"
 			args := []string{
-				"--server-base-path", "${RENKU_BASE_URL_PATH}",
+				"--server-base-path", "${RENKU_BASE_URL_PATH}/",
 				"--host", "${RENKU_SESSION_IP}",
 				"--port", "${RENKU_SESSION_PORT}",
 				"--extensions-dir", "${RENKU_MOUNT_DIR}/.vscode/extensions",

--- a/build_test.go
+++ b/build_test.go
@@ -157,7 +157,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Type:    "web",
 				Command: "codium-server",
 				Args: []string{
-					"--server-base-path", "${RENKU_BASE_URL_PATH}",
+					"--server-base-path", "${RENKU_BASE_URL_PATH}/",
 					"--host", "${RENKU_SESSION_IP}",
 					"--port", "${RENKU_SESSION_PORT}",
 					"--extensions-dir", "${RENKU_MOUNT_DIR}/.vscode/extensions",


### PR DESCRIPTION
Without the slash at the end you just get a 404 in renkulab.io.

See the same command in renkulab docker images at https://github.com/SwissDataScienceCenter/renkulab-docker/blob/main/docker/vscode/entrypoint.sh#L5