### PR TITLE
feat: use RENKU_FRONTENDS env variable in detection

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -1,12 +1,18 @@
 package vscodiumbuildpack
 
 import (
+	"os"
+	"strings"
+
 	"github.com/paketo-buildpacks/packit/v2"
 )
 
 type VersionParser interface {
 	ResolveVersion(cnbPath, version string) (resultVersion string, err error)
 }
+
+const RenkuFrontendEnvKey = "RENKU_FRONTENDS"
+const RenkuFrontendEnvValue = "vscodium"
 
 type BuildPlanMetadata struct {
 	Version       string `toml:"version,omitempty"`
@@ -17,6 +23,10 @@ type BuildPlanMetadata struct {
 func Detect(versionParser VersionParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
 
+		val := os.Getenv(RenkuFrontendEnvKey)
+		if !strings.Contains(strings.ToLower(val), RenkuFrontendEnvValue) {
+			return packit.DetectResult{}, packit.Fail.WithMessage("coulld not find the %s environment variable or its value does not contain %s", RenkuFrontendEnvKey, RenkuFrontendEnvValue)
+		}
 		plan := packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,6 +2,7 @@ package vscodiumbuildpack_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	vscodium "github.com/SwissDataScienceCenter/vscodium-buildpack"
@@ -18,17 +19,28 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		workingDir string
 
-		versionParser *fakes.VersionParser
-		detect        packit.DetectFunc
+		versionParser       *fakes.VersionParser
+		detect              packit.DetectFunc
+		originalFrontendVar string
 	)
 
 	it.Before(func() {
+		originalFrontendVar = os.Getenv(vscodium.RenkuFrontendEnvKey)
+		os.Setenv(vscodium.RenkuFrontendEnvKey, vscodium.RenkuFrontendEnvValue)
 		workingDir = t.TempDir()
 
 		versionParser = &fakes.VersionParser{}
 		versionParser.ResolveVersionCall.Returns.ResultVersion = "1.96.*"
 
 		detect = vscodium.Detect(versionParser)
+	})
+
+	it.After(func() {
+		if originalFrontendVar == "" {
+			os.Unsetenv(vscodium.RenkuFrontendEnvKey)
+		} else {
+			os.Setenv(vscodium.RenkuFrontendEnvKey, originalFrontendVar)
+		}
 	})
 
 	it("returns a plan that provides vscodium", func() {


### PR DESCRIPTION
Checks is vscodium is contained in the env var. If not then the buildpack will not apply.