### PR TITLE
fix: get only first cnb file in multi-arch release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "tag_full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag_minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag_major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "download_cnb_url=$(echo '${{needs.build-and-publish-buildpack.outputs.assets}}'|jq -r '.[]| select(.name | endswith(".cnb")) | .url')" >> "$GITHUB_OUTPUT"
+          echo "download_cnb_url=$(echo '${{needs.build-and-publish-buildpack.outputs.assets}}'|jq -r '.[]| select(.name | endswith(".cnb")) | .url | .[0]')" >> "$GITHUB_OUTPUT"
           echo "download_tgz_url=$(echo '${{needs.build-and-publish-buildpack.outputs.assets}}'|jq -r '.[]| select(.name | endswith(".tgz")) | .url')" >> "$GITHUB_OUTPUT"
 
       - name: Download .cnb buildpack


### PR DESCRIPTION
Because of the multi-arch building, the output generates multiple `.cnb` files.

Select the first one to get the digest.