### PR TITLE
Fix: VSCodium server base path configuration

### DIFF
--- a/build.go
+++ b/build.go
@@ -77,7 +77,7 @@ func Build(
 		if launch {
 			command := "codium-server"
 			args := []string{
-				"--server-base-path", "${RENKU_BASE_URL_PATH%/}/",
+				"--server-base-path", "${RENKU_BASE_URL_PATH%/}",
 				"--host", "${RENKU_SESSION_IP}",
 				"--port", "${RENKU_SESSION_PORT}",
 				"--extensions-dir", "${RENKU_MOUNT_DIR}/.vscode/extensions",
@@ -132,7 +132,7 @@ func Build(
 		layer.LaunchEnv.Default("RENKU_SESSION_PORT", "8000")
 		layer.LaunchEnv.Default("RENKU_MOUNT_DIR", context.WorkingDir)
 		layer.LaunchEnv.Default("RENKU_WORKING_DIR", context.WorkingDir)
-		layer.LaunchEnv.Default("RENKU_BASE_URL_PATH", "/")
+		layer.LaunchEnv.Default("RENKU_BASE_URL_PATH", "")
 		layer.LaunchEnv.Default("VSCODIUM_EXTENSIONS", "ms-python.python ms-toolsai.jupyter")
 
 		logger.EnvironmentVariables(layer)

--- a/build_test.go
+++ b/build_test.go
@@ -131,7 +131,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"RENKU_SESSION_PORT.default":  "8000",
 			"RENKU_MOUNT_DIR.default":     workspaceDir,
 			"RENKU_WORKING_DIR.default":   workspaceDir,
-			"RENKU_BASE_URL_PATH.default": "/",
+			"RENKU_BASE_URL_PATH.default": "",
 			"VSCODIUM_EXTENSIONS.default": "ms-python.python ms-toolsai.jupyter",
 		}))
 		Expect(layer.Metadata).To(Equal(map[string]interface{}{
@@ -158,7 +158,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Type:    "vscodium",
 				Command: "codium-server",
 				Args: []string{
-					"--server-base-path", "${RENKU_BASE_URL_PATH%/}/",
+					"--server-base-path", "${RENKU_BASE_URL_PATH%/}",
 					"--host", "${RENKU_SESSION_IP}",
 					"--port", "${RENKU_SESSION_PORT}",
 					"--extensions-dir", "${RENKU_MOUNT_DIR}/.vscode/extensions",


### PR DESCRIPTION
Previously, setting `--server-base-path` to `/` caused the VSCodium server to break. This change modifies the configuration to set an empty value for `server-base-path`, which makes the `codium-server` ignore the option, resolving the issue.